### PR TITLE
Add `sfilter` method; filters on `eval` expression

### DIFF
--- a/dictregister/dictregister.py
+++ b/dictregister/dictregister.py
@@ -128,6 +128,25 @@ class DictRegister(list):
             filtered_list = []
         return DictRegister(starting_list)
 
+    def sfilter(self, where_expr):
+        """Returns a DictRegister which contains only the
+        elements that match the given specifications.
+
+        where_expr is a Python `eval` expression that is evaluated in the context of the dict element
+
+        E.g.:
+          - x == 1
+          - x == 1 and y == 2
+        """
+        starting_list = self[:]
+        filtered_list = []
+        for item in starting_list:
+            if eval(where_expr, item.copy()):
+                filtered_list.append(item)
+        starting_list = filtered_list
+        filtered_list = []
+        return DictRegister(starting_list)
+
     def dget(self, **kwds):
         """Returns the first element that matches the
         given specification. If no elements are found

--- a/tests/test_dictregister.py
+++ b/tests/test_dictregister.py
@@ -154,6 +154,32 @@ def test_multiple_filter(fixdr):
     assert filtdr[0] == fixdr[0]
 
 
+def test_sfilter_and(fixdr):
+    filtdr = fixdr.sfilter('x == 1 and y == 2')
+    assert len(filtdr) == 1
+    assert filtdr[0] == fixdr[0]
+
+
+def test_sfilter_ne(fixdr):
+    filtdr = fixdr.sfilter('x != 3')
+    assert len(filtdr) == 1
+    assert filtdr[0] == {'x': 1, 'y': 2}
+    filtdr = fixdr.sfilter('x != 5')
+    assert len(filtdr) == 2
+    assert filtdr[0] == fixdr[0]
+    assert filtdr[1] == fixdr[1]
+
+
+def test_sfilter_fancy(fixdr):
+    filtdr = fixdr.sfilter('x + 1 == y')
+    assert len(filtdr) == 2
+    assert filtdr[0] == fixdr[0]
+    assert filtdr[1] == fixdr[1]
+    filtdr = fixdr.sfilter('x * 2 == y')
+    assert len(filtdr) == 1
+    assert filtdr[0] == fixdr[0]
+
+
 def test_dget_eq(fixdr):
     elem = fixdr.dget(x__eq=1)
     assert elem == {'x': 1, 'y': 2}


### PR DESCRIPTION
Rather than use Django ORM-style keyword arguments to filter, this is an alternative method, called `sfilter`, that lets you pass in a Python expression and it is actually executed using `eval`.

e.g.:

```
fixdr.sfilter('x == 1 and y == 2')
fixdr.sfilter('x + 1 == y')
```

I needed this for a project where I wanted to give the user the ability to filter in arbitrary ways from the command-line -- e.g.:

```
$ doula queue list --where "user_id == 'msabramo'"
```

I built the feature in that project, but then I thought it was kind of a generally useful thing to do so I started looking to see if there was a module on PyPI that did this. I couldn't find any, but I found two that do the ORM-like thing -- this one and [Lookupy](https://pypi.python.org/pypi/Lookupy). Since it's kind of similar, I decided to send a PR to see if it was something useful that you wanted to include.

I don't know about the name -- `sfilter` -- I guess I was thinking of "s" for "string". If you have better ideas, let me know.
